### PR TITLE
Fix remote ssh output buffer reading when sudo does not prompt for password

### DIFF
--- a/src/ssh2shell.coffee
+++ b/src/ssh2shell.coffee
@@ -48,7 +48,10 @@ class SSH2Shell extends EventEmitter
       if @_buffer.match(/password.*:\s$/i)
         @.emit 'msg', "#{@sshObj.server.host}: Send password [#{@sshObj.server.password}]" if @sshObj.debug
         @sshObj.pwSent = true
-        @_stream.write "#{@sshObj.server.password}\n"        
+        @_stream.write "#{@sshObj.server.password}\n"
+      #normal prompt so continue with next command
+      else if @_buffer.match(/[#$>]\s$/)
+        @_processNextCommand()
     #password sent so either check for failure or run next command  
     else
       #reprompted for password again so failed password 


### PR DESCRIPTION
Hi,

I have an sshd server config with 
```
PermitRootLogin without-password
```
I believe it s the fautly parameter. to be confirmed.

So that when i ```sudo ls``` it won t ask for password, the program was not able to handle that case correctly and ended into a command timeout.
I added simple check on prompt status and everything works fine again here !