### PR TITLE
Return the error on shell session failure. Change console.log to msg emit

### DIFF
--- a/lib/ssh2shell.js
+++ b/lib/ssh2shell.js
@@ -761,7 +761,7 @@
         this.emit('msg', this.sshObj.server.host + ": Next primary host");
       }
       host = this.hosts.pop();
-      console.log(host);
+      this.emit('msg', host);
       this.sshObj = host;
       this._initiate();
       return this._connect();

--- a/lib/ssh2shell.js
+++ b/lib/ssh2shell.js
@@ -798,7 +798,7 @@
             var i, len, pipe, ref;
             _this._stream = _stream;
             if (err) {
-              _this.emit('error', err, "Shell", true);
+              return _this.emit('error', err, "Shell", true);
             }
             if (_this.sshObj.debug) {
               _this.emit('msg', _this.sshObj.server.host + ": Connection.shell");


### PR DESCRIPTION
1-  I have a rest api that uses ssh2shell, and if there are multiple concurrent requests ssh2shell is crashing. See the output below. Adding return statement on error resolves the problem.

So my setup:
•	A collection of requests in postman that makes only GET requests to available routes
•	More than 7 collection runner (sometimes it can handle even 10) at a time
•	Request to the same IP
•	50 iterations for each collection runner




Server crashes with following:

Ready
192.168.1.120: Connection.error
192.168.1.120: Class.error
Error: MMI connection failed: 10010, Level: protocol
192.168.1.120: Connection.close
Closed
192.168.1.120: Class.error
Error: Unable to open shell, Level: undefined
192.168.1.120: Connection.shell
C:\code\restapi\node_modules\ssh2shell\lib\ssh2shell.js:807
            _this._stream.setEncoding(_this.sshObj.streamEncoding);
                          ^

TypeError: Cannot read property 'setEncoding' of undefined
    at C:\code\restapi\node_modules\ssh2shell\lib\ssh2shell.js:807:27
    at Array.<anonymous> (C:\code\restapi\node_modules\ssh2\lib\client.js:1362:14)
    at SSH2Stream.<anonymous> (C:\code\restapi\node_modules\ssh2\lib\Channel.js:117:19)
    at Object.onceWrapper (events.js:313:30)
    at emitNone (events.js:106:13)
    at SSH2Stream.emit (events.js:208:7)
    at Socket.<anonymous> (C:\code\restapi\node_modules\ssh2\lib\client.js:331:24)
    at emitOne (events.js:116:13)
    at Socket.emit (events.js:211:7)
    at TCP._handle.close [as _onclose] (net.js:557:12)
[nodemon] app crashed - waiting for file changes before starting...




**2-** Instead of writing the host output to the console, emit the message as usual. With this all ssh2shell logs covered by msg.send object.