### PR TITLE
Timer and listener clean up on session close

### DIFF
--- a/lib/ssh2shell.js
+++ b/lib/ssh2shell.js
@@ -846,7 +846,12 @@
               if (_this.sshObj.debug) {
                 _this.emit('msg', _this.sshObj.server.host + ": Stream.close");
               }
-              return _this.connection.end();
+              if (_this.sshObj.dataReceivedTimer) {
+                clearTimeout(_this.sshObj.dataReceivedTimer);
+              }
+              _this.removeAllListeners();
+              _this.connection.end();
+              return _this.connection.removeAllListeners();
             });
           });
         };

--- a/src/ssh2shell.coffee
+++ b/src/ssh2shell.coffee
@@ -522,7 +522,10 @@ class SSH2Shell extends EventEmitter
               
             @_stream.on "close", (code, signal) =>                          
               @.emit 'msg', "#{@sshObj.server.host}: Stream.close" if @sshObj.debug
+              clearTimeout @sshObj.dataReceivedTimer if @sshObj.dataReceivedTimer
+              @.removeAllListeners()
               @connection.end()
+              @connection.removeAllListeners()
           
         @connection.on "error", (err) =>
           @.emit 'msg', "#{@sshObj.server.host}: Connection.error" if @sshObj.debug


### PR DESCRIPTION
PR removes internal event listeners and clears out the data received timer when the session is closed.

Related issue: #62